### PR TITLE
Use lower bounds

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,4 +1,4 @@
 channels:
 - conda-forge
 dependencies:
-- pyiron_base =0.8.3
+- numpy =2.3.1

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,3 +2,4 @@ channels:
 - conda-forge
 dependencies:
 - numpy =2.3.1
+- setuptools >=68

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -2,4 +2,5 @@ channels:
   - conda-forge
 dependencies:
   - numpy =2.3.1
+  - setuptools >=68
   

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -1,5 +1,5 @@
 channels:
   - conda-forge
 dependencies:
-  - pyiron_base =0.8.3
+  - numpy =2.3.1
   

--- a/.ci_support/lower-bounds.yml
+++ b/.ci_support/lower-bounds.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
 dependencies:
-  - pyiron_base =0.8.0
+  - numpy =2.3.0
   - python =3.9
   

--- a/.ci_support/lower-bounds.yml
+++ b/.ci_support/lower-bounds.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+dependencies:
+  - pyiron_base =0.8.0
+  - python =3.9
+  

--- a/.ci_support/lower-bounds.yml
+++ b/.ci_support/lower-bounds.yml
@@ -2,5 +2,5 @@ channels:
   - conda-forge
 dependencies:
   - numpy =2.3.0
-  - python =3.9
+  - python =3.11
   

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -15,4 +15,5 @@ jobs:
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'
+      lower-bound-yaml: '.ci_support/lower-bounds.yml'
       publish-to-pypi: false

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -14,3 +14,6 @@ jobs:
     with:
       do-coveralls: false
       do-codecov: true
+      alternate-tests-env-files: .ci_support/lower-bounds.yml
+      alternate-tests-python-version: '3.9'
+      alternate-tests-dir: tests/unit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -14,6 +14,12 @@ jobs:
     with:
       do-coveralls: false
       do-codecov: true
+      # The test matrix supports up to four python versions
+      python-version-alt3: 'exclude'
+      python-version-alt2: '3.11'
+      python-version-alt1: '3.12'
+      python-version: '3.13'
+      # Test lower bounds:
       alternate-tests-env-files: .ci_support/lower-bounds.yml
-      alternate-tests-python-version: '3.9'
+      alternate-tests-python-version: '3.11'
       alternate-tests-dir: tests/unit

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ etc.
 Within this repository, the new module is called `pyiron_module_template` which should be renamed to `pyiron_IntendedModuleName`. 
 This can be easily achieved by modifying and running `bash ./update_module_name.sh` script.
 
-The licence is free to choose, but as a default the BSD3 licence packed here.
+The license is free to choose, but as a default the BSD3 licence packed here.
 
 ## Continuous Integration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ The default CI setup from [pyiron/actions](github.com/pyiron/actions) makes some
 The most important one is that your environment should be specified in `.ci_support/environment.yml`.
 There is a base environment there already, giving dependence on `numpy`.
 The CI will automatically keep environment files read by readthedocs (which will look at `.readthedocs.yml`) and MyBinder (which looks in `.binder`) up-to-date based on this environment file.
+Additionally, there is a specification of lower bounds in `.ci_support/lower-bounds.yml` which is used in the main push-pull workflow to run tests on older dependencies and to manage lower bounds for the jobs building packages for release.
 
 In case you need extra environment files for some setups, you can modify the workflows in `.github/workflows`, which accept input variables for the docs, tests, and notebooks environments.
 For example, it's typically good to not make your project depend on the `lammps` package, since this is not available for windows.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ etc.
 Within this repository, the new module is called `pyiron_module_template` which should be renamed to `pyiron_IntendedModuleName`. 
 This can be easily achieved by modifying and running `bash ./update_module_name.sh` script.
 
-The license is free to choose, but as a default the BSD3 licence packed here.
+The licence is free to choose, but as a default the BSD3 licence packed here.
 
 ## Continuous Integration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Make sure to go to [Codacy](https://www.codacy.com) and [Coverall](https://cover
 
 The default CI setup from [pyiron/actions](github.com/pyiron/actions) makes some assumptions about your directory structure.
 The most important one is that your environment should be specified in `.ci_support/environment.yml`.
-There is a base environment there already, giving dependence on `pyiron_base`.
+There is a base environment there already, giving dependence on `numpy`.
 The CI will automatically keep environment files read by readthedocs (which will look at `.readthedocs.yml`) and MyBinder (which looks in `.binder`) up-to-date based on this environment file.
 
 In case you need extra environment files for some setups, you can modify the workflows in `.github/workflows`, which accept input variables for the docs, tests, and notebooks environments.

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - sphinx-rtd-theme
 - versioneer
 - numpy =2.3.1
+- setuptools >=68

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,4 +7,4 @@ dependencies:
 - sphinx-gallery
 - sphinx-rtd-theme
 - versioneer
-- pyiron_base =0.8.3
+- numpy =2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "pyiron_base",
+    "numpy",
     "setuptools",
     "versioneer[toml]==0.29",
 ]
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "pyiron_base==0.8.3"
+    "numpy==2.3.1"
 ]
 dynamic = [ "version",]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
 requires = [
     "numpy",
-    "setuptools",
+    "setuptools>=68.0.0",
     "versioneer[toml]==0.29",
+
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,17 +11,16 @@ name = "pyiron_module_template"
 description = "pyiron_module_template - Your pyiron-like module."
 readme = "docs/README.md"
 keywords = [ "pyiron",]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.11, <3.14"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Scientific/Engineering",
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "numpy==2.3.1"


### PR DESCRIPTION
I totally forgot to turn this on for the package release in `bagofholding` and I wrote the damned template, so I think it would be useful to have it on by default.

I also take the opportunity to bump the supported python versions and depend on a more generic package.