### PR TITLE
Add verbose logging to update_module_name.sh

### DIFF
--- a/update_module_name.sh
+++ b/update_module_name.sh
@@ -3,6 +3,21 @@
 
 module_name="pyiron_IntendedModuleName"
 
+replace_and_log() {
+  local from="$1"
+  local to="$2"
+  local file="$3"
+  local count
+
+  count=$(grep -oF -- "$from" "$file" | wc -l)
+  if [ "$count" -gt 0 ]; then
+    printf 'Replacing "%s" with "%s" in %s (%s occurrence(s))\n' \
+      "$from" "$to" "$file" "$count"
+  fi
+
+  sed -i "s/${from}/${to}/g" "$file"
+}
+
 for file in .binder/postBuild \
             .github/ISSUE_TEMPLATE/*.md \
             docs/conf.py \
@@ -14,8 +29,8 @@ for file in .binder/postBuild \
             MANIFEST.in \
             pyproject.toml
 do
-  sed -i "s/pyiron_module_template/${module_name}/g" ${file}
-  sed -i "s/======================/${rst_delimit}/g" ${file}
+  replace_and_log "pyiron_module_template" "${module_name}" "${file}"
+  replace_and_log "======================" "${rst_delimit}" "${file}"
 done
 
 

--- a/update_module_name.sh
+++ b/update_module_name.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Mac users: You [may first need to install gnu-sed](https://github.com/MigleSur/GenAPI/issues/8)
 
+set -eu # exit script immediately on any error (e) and if used vars are unset (u)
+set -o pipefail # exit directly if pipeline fails anywhere and don't continue to next command
+
 module_name="pyiron_IntendedModuleName"
 
 replace_and_log() {

--- a/update_module_name.sh
+++ b/update_module_name.sh
@@ -12,8 +12,8 @@ replace_and_log() {
   local file="$3"
   local count
 
-  count=$(grep -oF -- "$from" "$file" | wc -l)
-  if [ "$count" -gt 0 ]; then
+  if grep -qF -- "$from" "$file"; then
+    count=$(grep -oF -- "$from" "$file" | wc -l)
     printf 'Replacing "%s" with "%s" in %s (%s occurrence(s))\n' \
       "$from" "$to" "$file" "$count"
   fi

--- a/update_module_name.sh
+++ b/update_module_name.sh
@@ -30,7 +30,6 @@ for file in .binder/postBuild \
             pyproject.toml
 do
   replace_and_log "pyiron_module_template" "${module_name}" "${file}"
-  replace_and_log "======================" "${rst_delimit}" "${file}"
 done
 
 


### PR DESCRIPTION
This change makes `update_module_name.sh` more transparent by printing each file where a replacement is performed,  along with the number of occurrences replaced.

- Added a small replace_and_log() helper to centralize substitution logic.
- Replaced the direct sed calls with helper calls that:
  - count matches before replacement
  - print the source string, target string, file path, and occurrence count
  - run the existing sed substitution afterward
- Removed the rst_delimit substitution.